### PR TITLE
Updated Footer Icon Styling with drop-shadow Filter

### DIFF
--- a/style.css
+++ b/style.css
@@ -204,10 +204,13 @@ p {
 
 @keyframes glowingEffect {
     0% {
-        box-shadow: 0 0 3px #fff, 0 0 6px #fff, 0 0 9px #fff, 0 0 12px #fff, 0 0 15px #fff, 0 0 18px #fff, 0 0 21px #fff;
+        filter: drop-shadow(0 0 5px rgba(255, 255, 255, 0.5));
+    }
+    50% {
+        filter: drop-shadow(0 0 10px rgba(247, 247, 247, 0.8));
     }
     100% {
-        box-shadow: 0 0 6px #fff, 0 0 12px #fff, 0 0 18px #fff, 0 0 24px #fff, 0 0 30px #fff, 0 0 36px #fff, 0 0 42px #fff;
+        filter: drop-shadow(0 0 5px rgba(255, 255, 255, 0.5));
     }
 }
 
@@ -225,16 +228,16 @@ footer {
     transition: transform var(--transition-speed) var(--ease-in-out), 
                 box-shadow var(--transition-speed) var(--ease-in-out);
     display: inline-block;
-    border-radius: 100%;
-    box-shadow: 3px 3px 6px rgba(0, 0, 0, 0.4);
+    /* box-shadow: 3px 3px 6px rgba(0, 0, 0, 0.4); */
 }
 
 .footer__icon:hover {
     transform: scale(1.05);
-    animation: glowingEffect 1.5s infinite alternate;
+    filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.5));
+    animation: glowingEffect 2s infinite alternate;
 } 
 
 .footer__icon:active {
     transform: scale(0.95);
-    animation: glowingEffect 1.5s infinite alternate;
+    animation: glowingEffect 2s infinite alternate;
 }


### PR DESCRIPTION
- Transitioned from using `box-shadow` to `filter: drop-shadow` for the footer icons to address the square background issue observed during hover animations.

